### PR TITLE
Creación de Makefile funcional con targets obligatorios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Makefile para Builder de Scripts de Monitoreo
+
+include .env
+
+.PHONY: tools build test run pack clean help
+
+tools: ## Verificación de herramientas necesarias
+	@echo "Verificando herramientas..."
+	@which curl >/dev/null || (echo "Error: curl no encontrado" && exit 1)
+	@which dig >/dev/null || (echo "Error: dig no encontrado" && exit 1)
+	@which nc >/dev/null || (echo "Error: nc no encontrado" && exit 1)
+	@which bats >/dev/null || (echo "Error: bats no encontrado" && exit 1)
+	@echo "Todas las herramientas están disponibles"
+
+build: tools ## Construcción de artefactos
+	@mkdir -p out
+	@echo "Construyendo scripts de monitoreo"
+	@bash src/builder.sh > out/monitor.sh
+	@chmod +x out/monitor.sh
+	@echo "Build completado en out/monitor.sh"
+
+test: build ## Ejecución de pruebas
+	@echo "Ejecutando suite de pruebas..."
+	@bats test/*.bats
+
+run: build ## Ejecución del monitoreo
+	@echo "Iniciando el monitoreo..."
+	@./out/monitor.sh
+
+pack: test ## Empaquetación final del código
+	@mkdir -p dist
+	@tar czf dist/monitor-$(RELEASE).tar.gz out/ src/ docs/
+	@echo "Paquete creado: dist/monitor-$(RELEASE).tar.gz"
+
+clean: ## Limpiar artefactos
+	@echo "Limpiando artefactos..."
+	@rm -rf out/ dist/
+
+help: ## Muestra de comandos de ayuda
+	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## Resumen
Implementación del Makefile principal con targets básicos y configuración inicial del sistema de build para el proyecto de monitoreo.

## Cambios incluidos
### Archivos nuevos:
- `Makefile` - Makefile principal con targets obligatorios

### Targets implementados:
- `tools` - Verificación de herramientas necesarias (curl, dig, nc, bats)
- `build` - Construcción de scripts de monitoreo
- `test` - Ejecución de pruebas con Bats
- `run` - Ejecución del monitoreo
- `pack` - Empaquetado para distribución
- `clean` - Limpieza de artefactos
- `help` - Ayuda del sistema

## Checklist
- [x] Makefile funcional con todos los targets básicos
- [x] Integración con variables de entorno
- [x] Manejo de errores en verificaciones
- [x] Documentación de uso en target help

## Imagen de prueba de funcionalidad
<img width="600" height="323" alt="build_core_sprint1" src="https://github.com/user-attachments/assets/b55f94bc-8871-4c4f-8a8f-cbf0283d3d12" />